### PR TITLE
#3 fix install task error where nested quotes weren't escaped correctly

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -44,7 +44,7 @@
             "command": "${workspaceFolder}/server/build/lua",
             "args": [
                 "-e",
-                "package.cpath = './server/build/?.so;' .. package.cpath",
+                "package.cpath = \"./server/build/?.so;\"",
                 "make/copy.lua",
                 "${command:extensionPath}",
             ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -44,7 +44,7 @@
             "command": "${workspaceFolder}/server/build/lua",
             "args": [
                 "-e",
-                "package.cpath = \"./server/build/?.so;\"",
+                "package.cpath = \"./server/build/?.so;\" .. package.cpath",
                 "make/copy.lua",
                 "${command:extensionPath}",
             ],


### PR DESCRIPTION
Hi,

As detailed my issue in #3 here is a fix that works for me.

This cpath argument line seems to work for me when installing from VSCode tasks. Here is the output after trying the change locally: 

```
> Executing task: /Users/pv/w/vscode-lua/server/build/lua -e 'package.cpath = "./server/build/?.so;"' make/copy.lua /Users/pv/.vscode/extensions/ <

./server/build/?.so;
copy    ./server/bin/macOS/lua-language-server  /Users/pv/.vscode/extensions/sumneko.lua-0.14.5/server/bin/macOS/lua-language-server
copy    ./server/bin/macOS/lpeglabel.so /Users/pv/.vscode/extensions/sumneko.lua-0.14.5/server/bin/macOS/lpeglabel.so
copy    ./server/bin/macOS/bee.so       /Users/pv/.vscode/extensions/sumneko.lua-0.14.5/server/bin/macOS/bee.so
copy    ./server/bin/macOS/lni.so       /Users/pv/.vscode/extensions/sumneko.lua-0.14.5/server/bin/macOS/lni.so
ok
```