### PR TITLE
Fix Install task on linux

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,6 +42,15 @@
         {
             "label": "Install",
             "command": "${workspaceFolder}/server/build/lua",
+            "linux": {
+                "command": "${workspaceFolder}/server/build/linux/bin/lua",
+                "args": [
+                    "-e",
+                    "package.cpath = \"./server/build/linux/bin/?.so;\" .. package.cpath",
+                    "make/copy.lua",
+                    "${command:extensionPath}",
+                ],
+            },
             "args": [
                 "-e",
                 "package.cpath = \"./server/build/?.so;\" .. package.cpath",


### PR DESCRIPTION
`luamake` generate outputs in `${workspaceFolder}/server/build/linux/bin` on linux.
I add a case for linux, and it works on my machine (ubuntu 18.04) .