### PR TITLE
Incorporate changes for semantic token improvements in extension scripts

### DIFF
--- a/package/configuration.lua
+++ b/package/configuration.lua
@@ -321,10 +321,12 @@ local config = {
         enum = {
             "Grammar",
             "Semantic",
+            "SemanticEnhanced",
         },
         markdownEnumDescriptions = {
             "%config.color.mode.Grammar%",
             "%config.color.mode.Semantic%",
+            "%config.color.mode.SemanticEnhanced%",
         },
         markdownDescription = "%config.color.mode%"
     },

--- a/package/nls-zh-cn.lua
+++ b/package/nls-zh-cn.lua
@@ -69,6 +69,7 @@ return {
     ['config.completion.requireSeparator']       = "`require` 时使用的分隔符。",
     ['config.color.mode']                        = "着色模式。",
     ['config.color.mode.Semantic']               = "语义着色。你可能需要同时将 `editor.semanticHighlighting.enabled` 设置为 `true` 才能生效。",
+    ['config.color.mode.SemanticEnhanced']       = "", -- TODO
     ['config.color.mode.Grammar']                = "语法着色。",
     ['config.signatureHelp.enable']              = "启用参数提示。",
     ['config.hover.enable']                      = "启用悬停提示。",

--- a/package/nls.lua
+++ b/package/nls.lua
@@ -69,6 +69,7 @@ Automatic detection and adaptation of third-party libraries, currently supported
     ['config.completion.requireSeparator']       = "The separator used when `require`.",
     ['config.color.mode']                        = "Color mode.",
     ['config.color.mode.Semantic']               = "Semantic color. You may need to set `editor.semanticHighlighting.enabled` to `true` to take effect.",
+    ['config.color.mode.SemanticEnhanced']       = "Enhanced semantic color. Like `Semantic`, but with additional analysis which might be more computationally expensive.",
     ['config.color.mode.Grammar']                = "Grammar color.",
     ['config.signatureHelp.enable']              = "Enable signature help.",
     ['config.hover.enable']                      = "Enable hover.",

--- a/package/semanticTokenScope.lua
+++ b/package/semanticTokenScope.lua
@@ -1,20 +1,34 @@
 return {
-    -- Lua库函数，如 print
-    ["namespace.static"] = {"support.function.lua"},
-    -- Lua库常量，如 _G
-    ["namespace.readonly"] = {"constant.language.lua"},
-    -- 全局变量
-    ["namespace.deprecated"] = {"entity.name.label"},
-    -- 参数声明
-    ['parameter.declaration'] = {"variable.parameter"},
-    -- table的field声明
-    ['property.declaration'] = {"entity.other.attribute"},
-    -- 局部变量
-    ['variable'] = {"variable.other.lua"},
-    -- const 变量
-    ['variable.static'] = {'variable.other.constant.lua'},
-    -- close 变量
+    -- 局部函数 | Local function
+    ['function'] = {'variable.function.lua'},
+    -- 自定义函数声明 | Custom function declaration
+    ['function.declaration'] = {'entity.name.function.lua'},
+    -- Lua库函数，如 print | Lua library functions, such as print
+    ['function.defaultLibrary'] = {'support.function.lua'},
+    -- 全局函数 | Global function
+    ['function.static'] = {'entity.name.function.lua'},
+    -- Class method
+    ['method'] = {'entity.name.function.lua'},
+    -- Class method declaration
+    ['method.declaration'] = {'entity.name.function.lua'},
+    -- 参数声明 | Parameter declaration
+    ['parameter.declaration'] = {'variable.parameter.lua'},
+    -- table的field声明 | Table field access
+    ['property'] = {'variable.other.property.lua'},
+    -- table的field声明 | Table field statement
+    ['property.declaration'] = {'entity.other.property.lua'},
+    -- Regular variable (modlue-local or otherwise not scoped)
+    ['variable'] = {'variable.other.lua'},
+    -- close 变量 | Close variable
     ['variable.abstract'] = {'variable.other.constant.lua'},
-    -- 自定义函数声明
-    ['interface.declaration'] = {"entity.name.function.lua"},
+    -- 局部变量 | Local variable
+    ['variable.declaration'] = {'variable.other.lua'},
+    -- Lua库常量，如 _G | Lua library constants, such as _G
+    ['variable.defaultLibrary'] = {'support.constant.lua'},
+    -- 局部变量 | Local variable
+    ['variable.local'] = {'variable.other.lua'},
+    -- const 变量 | Const variable
+    ['variable.readonly'] = {'variable.other.constant.lua'},
+    -- 全局变量 | Global variable
+    ['variable.static'] = {'variable.other.lua'},
 }


### PR DESCRIPTION
This PR is for the extension-side changes required for sumneko/lua-language-server#689, such as config schema changes, language changes, and Semantic Token type/modifier legend.

There is one language translation that will be needed for the new config option's description in the Chinese localization; I didn't want to run it through Google Translate and risk a poor translation, so I left that entry blank to be populated later (translation key is `config.color.mode.SemanticEnhanced`).