### PR TITLE
Provide validation schema for `.luarc.json`

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,6 +19,7 @@
 
 !images/logo.png
 
+!setting
 !syntaxes
 !package.json
 !README.md

--- a/package.json
+++ b/package.json
@@ -1577,6 +1577,12 @@
                 }
             }
         ],
+        "jsonValidation": [
+            {
+                "fileMatch": ".luarc.json",
+                "url": "./setting/schema.json"
+            }
+        ],
         "semanticTokenScopes": [
             {
                 "language": "lua",


### PR DESCRIPTION
Eliminates the need for `$schema` key in most cases:

![image](https://user-images.githubusercontent.com/79615454/156983764-2febc18a-ca7a-45b2-9945-680662681e4e.png)

`$schema` still takes precedence, so locale specific schema can still be used with
```
"$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.zh-cn.json",
```