### PR TITLE
ci: use ubuntu docker container to build linux releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04,   target: linux,   platform: linux-x64    }
-          - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64    }
+          - { os: ubuntu-20.04,   target: linux,   platform: linux-x64,   container: 'ubuntu:18.04' }
+          - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64, container: 'ubuntu:18.04' }
           - { os: macos-11,       target: darwin,  platform: darwin-x64   }
           - { os: macos-11,       target: darwin,  platform: darwin-arm64 }
           - { os: windows-latest, target: windows, platform: win32-ia32   }
           - { os: windows-latest, target: windows, platform: win32-x64    }
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container }}
     steps:
+      - name: Prepare container
+        if: ${{ matrix.target == 'linux' }}
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common curl sudo
+          add-apt-repository -y ppa:ubuntu-toolchain-r/test # For gcc-9 and g++-9
+          add-apt-repository -y ppa:git-core/ppa # For git>=2.18.
+          curl -sL https://deb.nodesource.com/setup_14.x -o /tmp/nodesource_setup.sh # For nodejs
+          sudo bash /tmp/nodesource_setup.sh
+          apt-get update
+          apt-get install -y git gcc-9 g++-9 nodejs
+
       - name: Install aarch64-linux-gnu
         if: ${{ matrix.platform == 'linux-arm64' }}
         run: |


### PR DESCRIPTION
Switch back to Ubuntu 18.04 for building linux releases. This allows for running these on older systems that do not provide GLIBC_2.29.


This is similar to the [lua-language-server](https://github.com/sumneko/lua-language-server) PR submitted the other day. I've only tested the `linux-x64` version, but both build successfully.

-----------------

Tested on an ubuntu 18:04 vagrant box.
```
vagrant@ubuntu-bionic:/vagrant$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 18.04.6 LTS
Release:        18.04
Codename:       bionic
```

Test with the 3.6.6 release (which errors with "GLIBC_2.29 not found")
```
vagrant@ubuntu-bionic:/vagrant$ ./vscode-lua-v3.6.6-linux-x64/extension/server/bin/lua-language-server
./vscode-lua-v3.6.6-linux-x64/extension/server/bin/lua-language-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by ./vscode-lua-v3.6.6-linux-x64/extension/server/bin/lua-language-server)
./vscode-lua-v3.6.6-linux-x64/extension/server/bin/lua-language-server: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./vscode-lua-v3.6.6-linux-x64/extension/server/bin/lua-language-server)
```

Test with the `linux-x64` artifact generated with this change.
```
vagrant@ubuntu-bionic:/vagrant$ ./vscode-lua-a2234b6-linux-x64/extension/server/bin/lua-language-server
Content-Length: 120

{"jsonrpc":"2.0","method":"$/status/report","params":{"text":"😺Lua","tooltip":"Cached files: 0/0\nMemory usage: 2M"}}
